### PR TITLE
Add PyPI trusted publishing instead of API token approach

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/pypi.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/pypi.yml
@@ -10,6 +10,8 @@ jobs:
   pypi-deploy:
     name: Deploying Python Package
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     steps:
     - uses: actions/checkout@v3
@@ -23,7 +25,4 @@ jobs:
     - name: Build SDist
       run: pipx run build --sdist
 
-    - uses: pypa/gh-action-pypi-publish@master
-      with:
-        user: __token__
-        password: {% raw %}${{ secrets.PYPI_API_TOKEN }}{% endraw %}
+    - uses: pypa/gh-action-pypi-publish@v1

--- a/{{cookiecutter.project_slug}}/TODO.md
+++ b/{{cookiecutter.project_slug}}/TODO.md
@@ -8,10 +8,14 @@ The following tasks need to be done to get a fully working project:
 {%- else -%}
 * Push to your remote repository for the first time by doing `git push origin main`.
 {%- endif %}
-* Add the secret variable `PYPI_API_TOKEN` to your GitHub project. This can be done in your
-  use settings at `https://pypi.org`. Note that currently, you have to create an unscoped token
-  for your first upload and only after that you can create a new token whose scope is restricted
-  to the current project.
+* Head to your user settings at `https://pypi.org` and setup PyPI trusted publishing.
+  In order to do so, you have to head to the "Publishing" tab, scroll to the bottom
+  and add a "new pending publisher". The relevant information is:
+  * PyPI project name: `{{ cookiecutter|modname }}`
+  * Owner: `{{ cookiecutter|username }}`
+  * Repository name: `{{ cookiecutter.project_slug }}`
+  * Workflow name: `pypi.yml`
+  * Environment name: not required
 * Enable the integration of Readthedocs with your Git hoster. In the case of Github, this means
   that you need to login at [Read the Docs](https://readthedocs.org) and click the button
   *Import a Project*.


### PR DESCRIPTION
This fixes #30 