### PR TITLE
Remove outdated nbsphinx_link

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -59,7 +59,6 @@ conditional_remove("{{ cookiecutter.github_actions_ci }}" == "No", "codecov.yml"
 conditional_remove("{{ cookiecutter.gitlab_ci }}" == "No", ".gitlab-ci.yml")
 conditional_remove(not {{ have_precommit }}, ".pre-commit-config.yaml")
 conditional_remove("{{ cookiecutter.notebooks }}" == "No", "notebooks")
-conditional_remove("{{ cookiecutter.notebooks }}" == "No", "doc/demo.nblink")
 conditional_remove("{{ cookiecutter.commandlineinterface }}" == "No", "src/{{ cookiecutter|modname }}/__main__.py")
 conditional_remove("{{ cookiecutter.commandlineinterface }}" == "No", "tests/test_cli.py")
 conditional_remove(os.stat("TODO.md").st_size == 0, "TODO.md")

--- a/{{cookiecutter.project_slug}}/doc/conf.py
+++ b/{{cookiecutter.project_slug}}/doc/conf.py
@@ -19,7 +19,6 @@ author = '{{ cookiecutter.full_name }}'
 extensions = [
 {%- if cookiecutter.notebooks == "Yes" %}
     "nbsphinx",
-    "nbsphinx_link",
 {%- endif %}
     "sphinx_mdinclude",
     "sphinx.ext.autodoc",

--- a/{{cookiecutter.project_slug}}/doc/demo.nblink
+++ b/{{cookiecutter.project_slug}}/doc/demo.nblink
@@ -1,3 +1,0 @@
-{
-    "path": "../notebooks/demo.ipynb"
-}

--- a/{{cookiecutter.project_slug}}/doc/index.rst
+++ b/{{cookiecutter.project_slug}}/doc/index.rst
@@ -7,7 +7,7 @@
 
    intro
 {%- if cookiecutter.notebooks == "Yes" %}
-   demo
+   ../notebooks/demo.ipynb
 {%- endif %}
    api
 

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -60,7 +60,6 @@ docs = [
 {%- if cookiecutter.notebooks == "Yes" %}
     "ipykernel",
     "nbsphinx",
-    "nbsphinx-link",
 {%- endif %}
     "sphinx",
     "sphinx_mdinclude",


### PR DESCRIPTION
This pull request makes a minor adjustment to the documentation configuration by removing the `nbsphinx-link` extension from both the Sphinx configuration and the documentation dependencies. This simplifies the setup when notebooks are enabled.

- Removed `nbsphinx_link` from the `extensions` list in `conf.py`, so it is no longer loaded as a Sphinx extension.
- Removed `nbsphinx-link` from the documentation dependencies in `pyproject.toml`, so it will no longer be installed.