### PR TITLE
Fix pre commit config generation

### DIFF
--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -3,7 +3,7 @@ name: Sync template repository
 on:
   push:
     branches:
-      - fix-pre-commit-config-generation
+      - main
   workflow_dispatch:
     inputs:
       sync:
@@ -48,7 +48,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         repository: ssciwr/python-project-template
-        ref: sync-test
+        ref: main
         path: target-repository
         ssh-key: ${{ secrets.SSCIWR_PYTHON_PROJECT_TEMPLATE_DEPLOY_KEY }}
 
@@ -75,4 +75,4 @@ jobs:
         git commit -m "Sync from ssciwr/cookiecutter-python-project" || echo "No changes"
 
         echo "Pushing changes to target repository..."
-        git push origin sync-test
+        git push origin main

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -3,7 +3,7 @@ name: Sync template repository
 on:
   push:
     branches:
-      - sync-project-template
+      - fix-pre-commit-config-generation
   workflow_dispatch:
     inputs:
       sync:

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -3,7 +3,7 @@ name: Sync template repository
 on:
   push:
     branches:
-      - main
+      - sync-project-template
   workflow_dispatch:
     inputs:
       sync:
@@ -21,6 +21,9 @@ jobs:
       uses: actions/checkout@v6
       with:
         path: cookiecutter-repository
+
+    - name: Install pre-commit
+      run: pip install pre-commit
 
     - name: Install cookiecutter
       run: pip install cookiecutter
@@ -45,7 +48,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         repository: ssciwr/python-project-template
-        ref: main
+        ref: sync-test
         path: target-repository
         ssh-key: ${{ secrets.SSCIWR_PYTHON_PROJECT_TEMPLATE_DEPLOY_KEY }}
 
@@ -72,4 +75,4 @@ jobs:
         git commit -m "Sync from ssciwr/cookiecutter-python-project" || echo "No changes"
 
         echo "Pushing changes to target repository..."
-        git push origin main
+        git push origin sync-test

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -24,12 +24,12 @@ class GitRepository(object):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         # Finalize by making an initial git commit
-        subprocess.check_call("git add *".split())
+        subprocess.check_call(["git", "add", "-A"])
 
         # Maybe run pre-commit
         if {{ have_precommit }}:
             subprocess.call("pre-commit run -a".split())
-            subprocess.check_call("git add *".split())
+            subprocess.check_call(["git", "add", "-A"])
 
         subprocess.check_call(["git", "commit", "-m", "Initial Commit"])
         subprocess.check_call(["git", "tag", "v0.0.1"])


### PR DESCRIPTION
CI on sync-test branch of python-project-template passes, and pre-commit-config.yml is generated.

I also changed "git add *" to "git add -A" in [post_gen_project.py](../blob/master/hooks/post_gen_project.py), as suggested by @thomasisensee .